### PR TITLE
Fix test paths and add board client service

### DIFF
--- a/src/services/board-service.ts
+++ b/src/services/board-service.ts
@@ -1,0 +1,48 @@
+export const BoardService = {
+  async listBoards() {
+    const res = await fetch('/api/boards');
+    if (!res.ok) {
+      throw new Error(`Failed to list boards: ${res.status}`);
+    }
+    return res.json();
+  },
+
+  async createBoard(title: string) {
+    const res = await fetch('/api/boards', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title }),
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error ?? `Failed to create board: ${res.status}`);
+    }
+    return res.json();
+  },
+
+  async deleteBoard(boardId: string) {
+    const res = await fetch(`/api/boards/${boardId}`, { method: 'DELETE' });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error ?? `Failed to delete board: ${res.status}`);
+    }
+  },
+
+  async getBoard(boardId?: string) {
+    if (!boardId) {
+      let list;
+      try {
+        list = await this.listBoards();
+      } catch (err: any) {
+        throw new Error(`Failed to fetch boards list: ${err.message.split(': ').pop()}`);
+      }
+      if (!list.length) throw new Error('No boards available');
+      boardId = list[0].id;
+    }
+    const res = await fetch(`/api/boards?boardId=${boardId}`);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch boards list: ${res.status}`);
+    }
+    return res.json();
+  },
+};

--- a/tests/boards-id-route.test.ts
+++ b/tests/boards-id-route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import prisma from '~/lib/prisma';
-import { PATCH, DELETE, BoardInputSchema } from '~/app/api/boards/[id]/route';
+import { PATCH, DELETE, BoardInputSchema } from '~/app/api/boards/[boardId]/[id]/route';
 
 // Mock Prisma methods
 vi.mock('~/lib/prisma', () => ({

--- a/tests/cards-move-route-stress.test.ts
+++ b/tests/cards-move-route-stress.test.ts
@@ -1,14 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { POST } from '~/app/api/cards/[id]/move/route';
+import { POST } from '~/app/api/cards/[cardId]/move/route';
 import prisma from '~/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '~/lib/auth/authOptions';
+
+vi.mock('next-auth/next', () => ({ getServerSession: vi.fn() }));
 
 // Fake timers to control backoff delays
 vi.useFakeTimers();
+
+const mockGetSession = getServerSession as unknown as ReturnType<typeof vi.fn>;
 
 describe('POST /api/cards/:id/move retry logic', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.useFakeTimers();
+    mockGetSession.mockResolvedValue({ user: { id: 'u1' } });
   });
 
   afterEach(() => {
@@ -95,6 +102,7 @@ describe('POST /api/cards/:id/move robust behavior under various scenarios', () 
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.useFakeTimers();
+    mockGetSession.mockResolvedValue({ user: { id: 'u1' } });
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- fix import paths for board and card routes in tests
- create a client `BoardService` with basic CRUD helpers
- adjust board route tests for updated prisma calls
- mock `getServerSession` in card move route tests

## Testing
- `npm test` *(fails: TypeError and timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_686c7f75ac88832d9d74a1783ebe55fa